### PR TITLE
fix jwt token - bypass jwt usage for destination service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+# added by cds bind
+.cdsrc-private.json
+node_modules

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "command": "DEBUG=remote cds-ts watch --profile hybrid",
+      "name": "cds-ts watch",
+      "request": "launch",
+      "type": "node-terminal",
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "credentials": {
           "destination": "azure-dest",
           "requestTimeout": 1000000,
-          "forwardAuthToken": true
+          "forwardAuthToken": false
         }
       },
       "apim-dest": {

--- a/srv/api-receiver.ts
+++ b/srv/api-receiver.ts
@@ -29,9 +29,10 @@ class ApiReceiver extends ApplicationService {
       const eventData = <ApiEvent>req.data;
       const reqIncomingMsg = <unknown>req;
       const azureJwt = retrieveJwt(<IncomingMessage>reqIncomingMsg);
+      const azuretoken = (req.headers as any).azuretoken;
       const apiMetadata: NewApiData = await this.getApiMetadata(
         eventData,
-        azureJwt
+        azuretoken
       );
       const proxyExists: NewApiData = await this.getApiDataByKey(
         `${apiMetadata.name}`
@@ -53,12 +54,12 @@ class ApiReceiver extends ApplicationService {
 
   private getApiMetadata = async (
     eventData: ApiEvent,
-    jwt?: String
+    azuretoken?: any
   ): Promise<NewApiData> => {
     const azureapi: Service = await cds.connect.to("azureapi");
     const { subject } = eventData;
     const sendHeaders: any = {
-      Authorization: `Bearer ${jwt}`,
+      Authorization: `Bearer ${azuretoken}`,
       "Ocp-Apim-Subscription-Key": process.env.AZURE_API_KEY,
     };
     // @ts-ignore


### PR DESCRIPTION
provide the azure token as a custom header property named "azuretoken" (that's the name that api-receiver.ts is expecting) to bypass the SAP Cloud SDK issue. 